### PR TITLE
Feature #156538205 - Add metadata to plot tooltip

### DIFF
--- a/__test__/__snapshots__/ClusterTSnePlot.test.js.snap
+++ b/__test__/__snapshots__/ClusterTSnePlot.test.js.snap
@@ -73,16 +73,6 @@ Array [
         <img
           src="test-file-stub"
         />
-        <p>
-          <small>
-            Powered by 
-            <a
-              href="https://loading.io"
-            >
-              loading.io
-            </a>
-          </small>
-        </p>
       </div>
     </div>
   </div>,

--- a/__test__/__snapshots__/GeneExpressionTSnePlot.test.js.snap
+++ b/__test__/__snapshots__/GeneExpressionTSnePlot.test.js.snap
@@ -172,16 +172,6 @@ Array [
         <img
           src="test-file-stub"
         />
-        <p>
-          <small>
-            Powered by 
-            <a
-              href="https://loading.io"
-            >
-              loading.io
-            </a>
-          </small>
-        </p>
       </div>
     </div>
   </div>,

--- a/html/Demo.js
+++ b/html/Demo.js
@@ -14,16 +14,20 @@ class Demo extends React.Component {
       perplexity: perplexities[Math.round((perplexities.length - 1) / 2)],
       geneId: ``,
       inputHighlightClusters: ``,
-      highlightClusters: []
+      highlightClusters: [],
+      inputExperimentAccession: `E-ENAD-13`,
+      experimentAccession: `E-ENAD-13`
     }
 
-    this._handleChange = this._handleChange.bind(this)
+    this._handleInputChange = this._handleInputChange.bind(this)
     this._handleSubmit = this._handleSubmit.bind(this)
   }
 
-  _handleChange(event) {
+  _handleInputChange(event) {
+    const name = event.target.name
+
     this.setState({
-      inputHighlightClusters: event.target.value
+      [name]: event.target.value
     })
   }
 
@@ -31,11 +35,10 @@ class Demo extends React.Component {
     event.preventDefault()
 
     this.setState({
+      experimentAccession: this.state.inputExperimentAccession,
       highlightClusters: this.state.inputHighlightClusters.split(`,`).map((e) => parseInt(e.trim())).filter((e) => !isNaN(e))
     })
   }
-
-
 
   render() {
     return(
@@ -43,14 +46,16 @@ class Demo extends React.Component {
         <div className={`row column`}>
           <form onSubmit={this._handleSubmit}>
             <label>Highlight clusters (cluster integer IDs separated by commas):</label>
-            <input type={`text`} onChange={this._handleChange} value={this.state.inputHighlightClusters}/>
+            <input name={`inputHighlightClusters`} type={`text`} onChange={this._handleInputChange} value={this.state.inputHighlightClusters}/>
+            <label>Experiment accession:</label>
+            <input name={`inputExperimentAccession`} type={`text`} onChange={this._handleInputChange} value={this.state.inputExperimentAccession}/>
             <input className={`button`} type="submit" value="Submit" />
           </form>
         </div>
 
         <ExperimentPageView atlasUrl={`http://localhost:8080/scxa/`}
                             suggesterEndpoint={`json/suggestions`}
-                            experimentAccession={`E-GEOD-106540`}
+                            experimentAccession={this.state.experimentAccession}
                             perplexities={perplexities}
                             selectedPerplexity={this.state.perplexity}
                             ks={ks}

--- a/html/Demo.js
+++ b/html/Demo.js
@@ -15,8 +15,8 @@ class Demo extends React.Component {
       geneId: ``,
       inputHighlightClusters: ``,
       highlightClusters: [],
-      inputExperimentAccession: `E-ENAD-13`,
-      experimentAccession: `E-ENAD-13`
+      inputExperimentAccession: `E-ENAD-14`,
+      experimentAccession: `E-ENAD-14`
     }
 
     this._handleInputChange = this._handleInputChange.bind(this)

--- a/src/ClusterTSnePlot.js
+++ b/src/ClusterTSnePlot.js
@@ -73,20 +73,23 @@ const ClusterTSnePlot = (props) => {
     tooltip: {
       formatter: function(tooltip) {
         const text = 'Loading metadata...'
+        const header = `<b>Cell ID:</b> ${this.point.name} <br> <b>Cluster ID:</b> ${this.series.name} <br/>`
 
         tooltipContent(this.point.name)
           .then((response) => {
+            const content = response.map((metadata) => {
+              return `<b>${metadata.displayName}:</b> ${metadata.value}`
+            })
+
             tooltip.label.attr({
-              text: `<b>Cell ID:</b> ${this.point.name} <br>` +
-                    `<b>Cluster ID:</b> ${this.series.name} <br>` +
-                    `<b>Inferred cell type:</b> ${response.inferredCellType}`
+              text: header + content.join("<br/>")
             });
           })
           .catch((reason) => {
             return `failure`
           })
 
-        return text
+        return header + text
       }
     }
   }

--- a/src/ClusterTSnePlot.js
+++ b/src/ClusterTSnePlot.js
@@ -21,18 +21,18 @@ const _colourizeClusters = (highlightSeries) =>
     }
   })
 
+const _tooltipFormatter = (cellId) => {
+  return `Request for ${cellId} goes here`
+}
+
 const ClusterTSnePlot = (props) => {
   const {ks, selectedK, onChangeK, perplexities, selectedPerplexity, onChangePerplexity} = props  // Select
-  const {plotData, highlightClusters, height} = props   // Chart
+  const {plotData, highlightClusters, height, tooltipContent} = props   // Chart
   const {loading, resourcesUrl, errorMessage} = props   // Overlay
 
   const highchartsConfig = {
     plotOptions: {
       scatter: {
-        tooltip: {
-          headerFormat: `<b>{series.name}</b><br>`,
-          pointFormat: `{point.name}`
-        },
         marker: {
           symbol: `circle`
         }
@@ -69,6 +69,25 @@ const ClusterTSnePlot = (props) => {
     },
     legend: {
       enabled: false
+    },
+    tooltip: {
+      formatter: function(tooltip) {
+        const text = 'Loading metadata...'
+
+        tooltipContent(this.point.name)
+          .then((response) => {
+            tooltip.label.attr({
+              text: `<b>Cell ID:</b> ${this.point.name} <br>` +
+                    `<b>Cluster ID:</b> ${this.series.name} <br>` +
+                    `<b>Inferred cell type:</b> ${response.inferredCellType}`
+            });
+          })
+          .catch((reason) => {
+            return `failure`
+          })
+
+        return text
+      }
     }
   }
 
@@ -125,7 +144,9 @@ ClusterTSnePlot.propTypes = {
 
   loading: PropTypes.bool.isRequired,
   resourcesUrl: PropTypes.string,
-  errorMessage: PropTypes.string
+  errorMessage: PropTypes.string,
+
+  tooltipContent: PropTypes.func
 }
 
 export {ClusterTSnePlot as default, _colourizeClusters}

--- a/src/TSnePlotView.js
+++ b/src/TSnePlotView.js
@@ -75,7 +75,7 @@ class TSnePlotView extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.selectedPerplexity !== this.props.selectedPerplexity) {
+    if (nextProps.selectedPerplexity !== this.props.selectedPerplexity || nextProps.experimentAccession !== this.props.experimentAccession) {
       this._fetchAndSetStateCellClusters(nextProps)
       this._fetchAndSetStateGeneId(nextProps)
     } else if (nextProps.selectedK !== this.props.selectedK) {
@@ -98,6 +98,11 @@ class TSnePlotView extends React.Component {
     const {loadingGeneExpression, geneExpressionData, geneExpressionErrorMessage} = this.state
     const {loadingCellClusters, cellClustersData, cellClustersErrorMessage} = this.state
 
+    const getTooltipContent = (cellId) => {
+      console.log(`Requesting metadata for cell id ${cellId}`)
+      return fetchResponseJson(atlasUrl, `json/experiment/${this.props.experimentAccession}/cell/${cellId}/metadata`)
+    }
+
     return (
       <div className={`row`}>
         <div className={`small-12 medium-6 columns`}>
@@ -113,6 +118,7 @@ class TSnePlotView extends React.Component {
                            loading={loadingCellClusters}
                            resourcesUrl={resourcesUrl}
                            errorMessage={cellClustersErrorMessage}
+                           tooltipContent={getTooltipContent}
           />
         </div>
 

--- a/src/TSnePlotView.js
+++ b/src/TSnePlotView.js
@@ -99,7 +99,6 @@ class TSnePlotView extends React.Component {
     const {loadingCellClusters, cellClustersData, cellClustersErrorMessage} = this.state
 
     const getTooltipContent = (cellId) => {
-      console.log(`Requesting metadata for cell id ${cellId}`)
       return fetchResponseJson(atlasUrl, `json/experiment/${this.props.experimentAccession}/cell/${cellId}/metadata`)
     }
 


### PR DESCRIPTION
* Added function that performs async call to retrieve metadata for a particular cell in an experiment
* Added custom tooltip formatter that displays the retrieved metadata
* Changed Demo page to include an input box for an experiment accession