### PR TITLE
Feature #161416337 - Allow ReactSelect dropdowns to be updated programmatically

### DIFF
--- a/src/PlotSettingsDropdown.js
+++ b/src/PlotSettingsDropdown.js
@@ -58,7 +58,7 @@ const PlotSettingsDropdown = (props) => {
       components={{ DropdownIndicator, IndicatorSeparator: null }}
       options={options}
       onChange={onSelect}
-      defaultValue={defaultValue}
+      value={defaultValue}
       formatGroupLabel={formatGroupLabel}
       styles={ebiVfSelectStyles} />
   ]

--- a/src/plotloader/ScatterPlot.js
+++ b/src/plotloader/ScatterPlot.js
@@ -36,12 +36,15 @@ const highchartsBaseConfig = {
 
   chart: {
     type: `scatter`,
-    borderWidth: 1,
-    borderColor: `dark blue`,
+    spacingLeft: 0,
     height: `100%`,
     panning: true,
     spacingTop: 50,
-    zoomType: `xy`
+    zoomType: `xy`,
+    plotBackgroundColor: `transparent`, // This needs to be set to allow access to this.plotBackground
+    events: {
+      load: function() { this.plotBackground.htmlCss({ cursor: `crosshair` }) }
+    }
   },
 
   legend: {
@@ -86,6 +89,7 @@ const highchartsBaseConfig = {
     }
   },
   xAxis: {
+    lineColor: `#e6e6e6`,
     title: {
       text: null
     },
@@ -95,6 +99,7 @@ const highchartsBaseConfig = {
     tickWidth: 0
   },
   yAxis: {
+    lineColor: `#e6e6e6`,
     title: {
       text: null
     },
@@ -110,7 +115,7 @@ const highchartsBaseConfig = {
   plotOptions: {
     series: {
       turboThreshold: 0,
-      animation: false,
+      animation: false
     }
   }
 }
@@ -124,7 +129,8 @@ const ScatterPlot = (props) => {
       {
         plotOptions: {
           series: {
-            marker: {radius: 3}
+            marker: {radius: 3},
+            stickyTracking: false
           }
         }
       },


### PR DESCRIPTION
Changed ReactSelect props to pass the dropdown selection as the value rather than the default value. This allows the dropdowns to be updated programatically. 

A notable side effect is that this causes an apparent decrease in performance when you make a new selection in the dropdown. Alternative suggestions are welcome.