### PR TITLE
Feature/163650272 add controls prop t sne plot

### DIFF
--- a/__test__/ClusterTSnePlot.test.js
+++ b/__test__/ClusterTSnePlot.test.js
@@ -76,40 +76,41 @@ describe(`ClusterTSnePlot colourize function`, () => {
 
 describe(`ClusterTSnePlot`, () => {
 
-  const onChangeColourBy = () => {}
-  const onChangePerplexity = () => {}
-  const plotData = {
-    series: []
+  const props = {
+    onChangeColourBy: () => {},
+    onChangePerplexity: () => {},
+    plotData: {
+      series: []
+    },
+    height: 500,
+    metadata: [],
+    ks: [],
+    perplexities: [],
+    loading: true
   }
-  const height = 500
-  const metadata = []
-  const ks = []
-  const perplexities = []
-  const loading = true
-
 
   test(`with no data matches snapshot`, () => {
     const tree = renderer
-      .create(<ClusterTSnePlot height={height} ks={ks} metadata={metadata} selectedColourBy={`0`} onChangeColourBy={onChangeColourBy} perplexities={perplexities} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={loading} plotData={plotData} showControls={true}/>)
+      .create(<ClusterTSnePlot {...props} selectedColourBy={`0`} selectedPerplexity={0} showControls={true}/>)
       .toJSON()
 
     expect(tree).toMatchSnapshot()
   })
 
   test(`contains ScatterPlotLoader`, () => {
-    const wrapper = mount(<ClusterTSnePlot height={height} ks={ks} metadata={metadata} selectedColourBy={`0`} onChangeColourBy={onChangeColourBy} perplexities={perplexities} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={loading} plotData={plotData} showControls={true}/>)
+    const wrapper = mount(<ClusterTSnePlot {...props} selectedColourBy={`0`} selectedPerplexity={0} showControls={true}/>)
 
     expect(wrapper.find(ScatterPlotLoader).length).toBe(1)
   })
 
   test(`contains 2 PlotSettingsDropdowns`, () => {
-    const wrapper = mount(<ClusterTSnePlot height={height} ks={ks} metadata={metadata} selectedColourBy={`0`} onChangeColourBy={onChangeColourBy} perplexities={perplexities} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={loading} plotData={plotData} showControls={true}/>)
+    const wrapper = mount(<ClusterTSnePlot {...props} selectedColourBy={`0`} selectedPerplexity={0} showControls={true}/>)
 
     expect(wrapper.find(PlotSettingsDropdown).length).toBe(2)
   })
 
   test(`contains only 1 PlotSettingsDropdowns when showControls is false`, () => {
-    const wrapper = mount(<ClusterTSnePlot height={height} ks={ks} metadata={metadata} selectedColourBy={`0`} onChangeColourBy={onChangeColourBy} perplexities={perplexities} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={loading} plotData={plotData} showControls={false}/>)
+    const wrapper = mount(<ClusterTSnePlot {...props} selectedColourBy={`0`} selectedPerplexity={0} showControls={false}/>)
 
     expect(wrapper.find(PlotSettingsDropdown).length).toBe(1)
   })
@@ -123,7 +124,7 @@ describe(`ClusterTSnePlot`, () => {
       }
     ]
 
-    const wrapper = mount(<ClusterTSnePlot height={height} ks={ks} metadata={metadata} selectedColourBy={`2`} onChangeColourBy={onChangeColourBy} perplexities={perplexities} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={loading} plotData={plotData}/>)
+    const wrapper = mount(<ClusterTSnePlot {...props} ks={ks} metadata={metadata} selectedColourBy={`2`} selectedPerplexity={0} showControls={true}/>)
 
     const dropdown = wrapper.find({ labelText: `Colour plot by:`})
 
@@ -140,7 +141,7 @@ describe(`ClusterTSnePlot`, () => {
       }
     ]
 
-    const wrapper = mount(<ClusterTSnePlot height={height} ks={ks} metadata={metadata} selectedColourBy={`metadata-1`} onChangeColourBy={onChangeColourBy} perplexities={perplexities} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={loading} plotData={plotData}/>)
+    const wrapper = mount(<ClusterTSnePlot {...props} ks={ks} metadata={metadata} selectedColourBy={`metadata-1`} selectedPerplexity={0} showControls={true}/>)
 
     const dropdown = wrapper.find({ labelText: `Colour plot by:`})
 

--- a/__test__/ClusterTSnePlot.test.js
+++ b/__test__/ClusterTSnePlot.test.js
@@ -75,13 +75,14 @@ describe(`ClusterTSnePlot colourize function`, () => {
 })
 
 describe(`ClusterTSnePlot`, () => {
-  test(`with no data matches snapshot`, () => {
-    const onChangeColourBy = () => {}
-    const onChangePerplexity = () => {}
-    const plotData = {
-      series: []
-    }
 
+  const onChangeColourBy = () => {}
+  const onChangePerplexity = () => {}
+  const plotData = {
+    series: []
+  }
+
+  test(`with no data matches snapshot`, () => {
     const tree = renderer
       .create(<ClusterTSnePlot height={500} ks={[]} metadata={[]} selectedColourBy={`0`} onChangeColourBy={onChangeColourBy} perplexities={[]} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={true} plotData={plotData}/>)
       .toJSON()
@@ -90,47 +91,24 @@ describe(`ClusterTSnePlot`, () => {
   })
 
   test(`contains ScatterPlotLoader`, () => {
-    const onChangeColourBy = () => {}
-    const onChangePerplexity = () => {}
-    const plotData = {
-      series: []
-    }
-
     const wrapper = mount(<ClusterTSnePlot height={500} ks={[]} metadata={[]} selectedColourBy={`0`} onChangeColourBy={onChangeColourBy} perplexities={[]} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={true} plotData={plotData}/>)
 
     expect(wrapper.find(ScatterPlotLoader).length).toBe(1)
   })
 
   test(`contains 2 PlotSettingsDropdowns`, () => {
-    const onChangeColourBy = () => {}
-    const onChangePerplexity = () => {}
-    const plotData = {
-      series: []
-    }
-
     const wrapper = mount(<ClusterTSnePlot height={500} ks={[]} metadata={[]} selectedColourBy={`0`} onChangeColourBy={onChangeColourBy} perplexities={[]} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={true} plotData={plotData}/>)
 
     expect(wrapper.find(PlotSettingsDropdown).length).toBe(2)
   })
 
   test(`contains no PlotSettingsDropdowns when flag is false`, () => {
-    const onChangeColourBy = () => {}
-    const onChangePerplexity = () => {}
-    const plotData = {
-      series: []
-    }
-
     const wrapper = mount(<ClusterTSnePlot height={500} ks={[]} metadata={[]} selectedColourBy={`0`} onChangeColourBy={onChangeColourBy} perplexities={[]} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={true} plotData={plotData} showControls={false}/>)
 
     expect(wrapper.find(PlotSettingsDropdown).length).toBe(0)
   })
 
   test(`dropdown selection text is to be "k = x" when plot is coloured by cluster ID x`, () => {
-    const onChangeColourBy = () => {}
-    const onChangePerplexity = () => {}
-    const plotData = {
-      series: []
-    }
     const ks = [1, 2, 3]
     const metadata = [
       {
@@ -148,11 +126,6 @@ describe(`ClusterTSnePlot`, () => {
   })
 
   test(`dropdown selection text is the name of the metadata when plot is coloured by metadata`, () => {
-    const onChangeColourBy = () => {}
-    const onChangePerplexity = () => {}
-    const plotData = {
-      series: []
-    }
     const ks = [1, 2, 3]
     const metadata = [
       {

--- a/__test__/ClusterTSnePlot.test.js
+++ b/__test__/ClusterTSnePlot.test.js
@@ -81,31 +81,37 @@ describe(`ClusterTSnePlot`, () => {
   const plotData = {
     series: []
   }
+  const height = 500
+  const metadata = []
+  const ks = []
+  const perplexities = []
+  const loading = true
+
 
   test(`with no data matches snapshot`, () => {
     const tree = renderer
-      .create(<ClusterTSnePlot height={500} ks={[]} metadata={[]} selectedColourBy={`0`} onChangeColourBy={onChangeColourBy} perplexities={[]} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={true} plotData={plotData}/>)
+      .create(<ClusterTSnePlot height={height} ks={ks} metadata={metadata} selectedColourBy={`0`} onChangeColourBy={onChangeColourBy} perplexities={perplexities} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={loading} plotData={plotData} showControls={true}/>)
       .toJSON()
 
     expect(tree).toMatchSnapshot()
   })
 
   test(`contains ScatterPlotLoader`, () => {
-    const wrapper = mount(<ClusterTSnePlot height={500} ks={[]} metadata={[]} selectedColourBy={`0`} onChangeColourBy={onChangeColourBy} perplexities={[]} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={true} plotData={plotData}/>)
+    const wrapper = mount(<ClusterTSnePlot height={height} ks={ks} metadata={metadata} selectedColourBy={`0`} onChangeColourBy={onChangeColourBy} perplexities={perplexities} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={loading} plotData={plotData} showControls={true}/>)
 
     expect(wrapper.find(ScatterPlotLoader).length).toBe(1)
   })
 
   test(`contains 2 PlotSettingsDropdowns`, () => {
-    const wrapper = mount(<ClusterTSnePlot height={500} ks={[]} metadata={[]} selectedColourBy={`0`} onChangeColourBy={onChangeColourBy} perplexities={[]} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={true} plotData={plotData}/>)
+    const wrapper = mount(<ClusterTSnePlot height={height} ks={ks} metadata={metadata} selectedColourBy={`0`} onChangeColourBy={onChangeColourBy} perplexities={perplexities} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={loading} plotData={plotData} showControls={true}/>)
 
     expect(wrapper.find(PlotSettingsDropdown).length).toBe(2)
   })
 
-  test(`contains no PlotSettingsDropdowns when flag is false`, () => {
-    const wrapper = mount(<ClusterTSnePlot height={500} ks={[]} metadata={[]} selectedColourBy={`0`} onChangeColourBy={onChangeColourBy} perplexities={[]} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={true} plotData={plotData} showControls={false}/>)
+  test(`contains only 1 PlotSettingsDropdowns when showControls is false`, () => {
+    const wrapper = mount(<ClusterTSnePlot height={height} ks={ks} metadata={metadata} selectedColourBy={`0`} onChangeColourBy={onChangeColourBy} perplexities={perplexities} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={loading} plotData={plotData} showControls={false}/>)
 
-    expect(wrapper.find(PlotSettingsDropdown).length).toBe(0)
+    expect(wrapper.find(PlotSettingsDropdown).length).toBe(1)
   })
 
   test(`dropdown selection text is to be "k = x" when plot is coloured by cluster ID x`, () => {
@@ -117,7 +123,7 @@ describe(`ClusterTSnePlot`, () => {
       }
     ]
 
-    const wrapper = mount(<ClusterTSnePlot height={500} ks={ks} metadata={metadata} selectedColourBy={`2`} onChangeColourBy={onChangeColourBy} perplexities={[]} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={true} plotData={plotData}/>)
+    const wrapper = mount(<ClusterTSnePlot height={height} ks={ks} metadata={metadata} selectedColourBy={`2`} onChangeColourBy={onChangeColourBy} perplexities={perplexities} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={loading} plotData={plotData}/>)
 
     const dropdown = wrapper.find({ labelText: `Colour plot by:`})
 
@@ -134,7 +140,7 @@ describe(`ClusterTSnePlot`, () => {
       }
     ]
 
-    const wrapper = mount(<ClusterTSnePlot height={500} ks={ks} metadata={metadata} selectedColourBy={`metadata-1`} onChangeColourBy={onChangeColourBy} perplexities={[]} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={true} plotData={plotData}/>)
+    const wrapper = mount(<ClusterTSnePlot height={height} ks={ks} metadata={metadata} selectedColourBy={`metadata-1`} onChangeColourBy={onChangeColourBy} perplexities={perplexities} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={loading} plotData={plotData}/>)
 
     const dropdown = wrapper.find({ labelText: `Colour plot by:`})
 

--- a/__test__/ClusterTSnePlot.test.js
+++ b/__test__/ClusterTSnePlot.test.js
@@ -113,6 +113,18 @@ describe(`ClusterTSnePlot`, () => {
     expect(wrapper.find(PlotSettingsDropdown).length).toBe(2)
   })
 
+  test(`contains no PlotSettingsDropdowns when flag is false`, () => {
+    const onChangeColourBy = () => {}
+    const onChangePerplexity = () => {}
+    const plotData = {
+      series: []
+    }
+
+    const wrapper = mount(<ClusterTSnePlot height={500} ks={[]} metadata={[]} selectedColourBy={`0`} onChangeColourBy={onChangeColourBy} perplexities={[]} selectedPerplexity={0} onChangePerplexity={onChangePerplexity} loading={true} plotData={plotData} showControls={false}/>)
+
+    expect(wrapper.find(PlotSettingsDropdown).length).toBe(0)
+  })
+
   test(`dropdown selection text is to be "k = x" when plot is coloured by cluster ID x`, () => {
     const onChangeColourBy = () => {}
     const onChangePerplexity = () => {}

--- a/__test__/GeneExpressionTSnePlot.test.js
+++ b/__test__/GeneExpressionTSnePlot.test.js
@@ -146,29 +146,36 @@ describe(`GeneExpressionTSnePlot colourize function`, () => {
 describe(`GeneExpressionTSnePlot`, () => {
 
   const onSelectGeneId = () => {}
+  const highlightClusters = []
+  const randomSeries = randomHighchartsSeriesWithSeed()
+  const expressionGradientColours = gradientColourRanges()
+  const height = 600
+  const loading = true
+  const atlasUrl = ``
+  const suggesterEndpoint = ``
+  const speciesName = ``
+
+
 
   test(`with random data matches snapshot`, () => {
-    const randomSeries = randomHighchartsSeriesWithSeed()
 
     const tree = renderer
-      .create(<GeneExpressionTSnePlot height={600} expressionGradientColours={gradientColourRanges()} atlasUrl={``} suggesterEndpoint={``} onSelectGeneId={onSelectGeneId} loading={true} plotData={plotData(randomSeries)} highlightClusters={[]} speciesName={``}/>)
+      .create(<GeneExpressionTSnePlot height={height} expressionGradientColours={expressionGradientColours} atlasUrl={atlasUrl} suggesterEndpoint={suggesterEndpoint} onSelectGeneId={onSelectGeneId} loading={loading} plotData={plotData(randomSeries)} highlightClusters={highlightClusters} speciesName={speciesName} showControls={true}/>)
       .toJSON()
 
     expect(tree).toMatchSnapshot()
   })
 
-  test(`contains no atlas autocomplete control when flag is false`, () => {
-    const randomSeries = randomHighchartsSeriesWithSeed()
+  test(`contains no atlas autocomplete control when showControls is false`, () => {
 
-    const wrapper = mount(<GeneExpressionTSnePlot height={600} expressionGradientColours={gradientColourRanges()} atlasUrl={``} suggesterEndpoint={``} onSelectGeneId={onSelectGeneId} loading={true} plotData={plotData(randomSeries)} highlightClusters={[]} speciesName={``} showControls={false}/>)
+    const wrapper = mount(<GeneExpressionTSnePlot height={height} expressionGradientColours={expressionGradientColours} atlasUrl={atlasUrl} suggesterEndpoint={suggesterEndpoint} onSelectGeneId={onSelectGeneId} loading={loading} plotData={plotData(randomSeries)} highlightClusters={highlightClusters} speciesName={speciesName} showControls={false}/>)
 
     expect(wrapper.find(AtlasAutocomplete).length).toBe(0)
   })
 
-  test(`contains atlas autocomplete control when flag is not specified`, () => {
-    const randomSeries = randomHighchartsSeriesWithSeed()
+  test(`contains atlas autocomplete control when showControls is true`, () => {
 
-    const wrapper = mount(<GeneExpressionTSnePlot height={600} expressionGradientColours={gradientColourRanges()} atlasUrl={``} suggesterEndpoint={``} onSelectGeneId={onSelectGeneId} loading={true} plotData={plotData(randomSeries)} highlightClusters={[]} speciesName={``}/>)
+    const wrapper = mount(<GeneExpressionTSnePlot height={height} expressionGradientColours={expressionGradientColours} atlasUrl={atlasUrl} suggesterEndpoint={suggesterEndpoint} onSelectGeneId={onSelectGeneId} loading={loading} plotData={plotData(randomSeries)} highlightClusters={highlightClusters} speciesName={speciesName} showControls={true}/>)
 
     expect(wrapper.find(AtlasAutocomplete).length).toBe(1)
   })

--- a/__test__/GeneExpressionTSnePlot.test.js
+++ b/__test__/GeneExpressionTSnePlot.test.js
@@ -11,9 +11,15 @@ import GeneExpressionTSnePlot from '../src/GeneExpressionTSnePlot'
 import AtlasAutocomplete from 'expression-atlas-autocomplete'
 
 import '../src/util/MathRound'
-import {gradientColourRanges, randomHighchartsSeries, randomHighchartsSeriesWithNamesAndMaxPoints, plotData, randomHighchartsSeriesWithSeed} from './Utils'
+import {
+  gradientColourRanges,
+  randomHighchartsSeries,
+  randomHighchartsSeriesWithNamesAndMaxPoints,
+  plotData,
+  randomHighchartsSeriesWithSeed
+} from './Utils'
 
-Enzyme.configure({ adapter: new Adapter() })
+Enzyme.configure({adapter: new Adapter()})
 
 describe(`GeneExpressionTSnePlot colourize function`, () => {
 
@@ -43,7 +49,7 @@ describe(`GeneExpressionTSnePlot colourize function`, () => {
 
   test(`assigns maximum colour scale to the point with highest expression`, () => {
     const randomSeries = randomHighchartsSeries()
-    const maximum = 10000;
+    const maximum = 10000
     randomSeries[randomSeries.length - 1].data.push({
       x: 0,
       y: 0,
@@ -137,30 +143,31 @@ describe(`GeneExpressionTSnePlot colourize function`, () => {
       max: 100.0
     }).forEach((series) => {
       series.data.forEach((point) => {
-          expect(point).toHaveProperty(`color`, Color(`lightgrey`).alpha(0.65).rgb().toString())
-        })
+        expect(point).toHaveProperty(`color`, Color(`lightgrey`).alpha(0.65).rgb().toString())
+      })
     })
   })
 })
 
 describe(`GeneExpressionTSnePlot`, () => {
 
-  const onSelectGeneId = () => {}
-  const highlightClusters = []
-  const randomSeries = randomHighchartsSeriesWithSeed()
-  const expressionGradientColours = gradientColourRanges()
-  const height = 600
-  const loading = true
-  const atlasUrl = ``
-  const suggesterEndpoint = ``
-  const speciesName = ``
-
+  const props = {
+    onSelectGeneId: () => {},
+    highlightClusters: [],
+    plotData: plotData(randomHighchartsSeriesWithSeed()),
+    expressionGradientColours: gradientColourRanges(),
+    height: 600,
+    loading: true,
+    atlasUrl: ``,
+    suggesterEndpoint: ``,
+    speciesName: ``
+  }
 
 
   test(`with random data matches snapshot`, () => {
 
     const tree = renderer
-      .create(<GeneExpressionTSnePlot height={height} expressionGradientColours={expressionGradientColours} atlasUrl={atlasUrl} suggesterEndpoint={suggesterEndpoint} onSelectGeneId={onSelectGeneId} loading={loading} plotData={plotData(randomSeries)} highlightClusters={highlightClusters} speciesName={speciesName} showControls={true}/>)
+      .create(<GeneExpressionTSnePlot {...props} showControls={true}/>)
       .toJSON()
 
     expect(tree).toMatchSnapshot()
@@ -168,14 +175,14 @@ describe(`GeneExpressionTSnePlot`, () => {
 
   test(`contains no atlas autocomplete control when showControls is false`, () => {
 
-    const wrapper = mount(<GeneExpressionTSnePlot height={height} expressionGradientColours={expressionGradientColours} atlasUrl={atlasUrl} suggesterEndpoint={suggesterEndpoint} onSelectGeneId={onSelectGeneId} loading={loading} plotData={plotData(randomSeries)} highlightClusters={highlightClusters} speciesName={speciesName} showControls={false}/>)
+    const wrapper = mount(<GeneExpressionTSnePlot {...props} showControls={false}/>)
 
     expect(wrapper.find(AtlasAutocomplete).length).toBe(0)
   })
 
   test(`contains atlas autocomplete control when showControls is true`, () => {
 
-    const wrapper = mount(<GeneExpressionTSnePlot height={height} expressionGradientColours={expressionGradientColours} atlasUrl={atlasUrl} suggesterEndpoint={suggesterEndpoint} onSelectGeneId={onSelectGeneId} loading={loading} plotData={plotData(randomSeries)} highlightClusters={highlightClusters} speciesName={speciesName} showControls={true}/>)
+    const wrapper = mount(<GeneExpressionTSnePlot {...props} showControls={true}/>)
 
     expect(wrapper.find(AtlasAutocomplete).length).toBe(1)
   })

--- a/__test__/GeneExpressionTSnePlot.test.js
+++ b/__test__/GeneExpressionTSnePlot.test.js
@@ -8,6 +8,7 @@ import Adapter from 'enzyme-adapter-react-16'
 
 import {_colourizeExpressionLevel} from '../src/GeneExpressionTSnePlot'
 import GeneExpressionTSnePlot from '../src/GeneExpressionTSnePlot'
+import AtlasAutocomplete from 'expression-atlas-autocomplete'
 
 import '../src/util/MathRound'
 import {gradientColourRanges, randomHighchartsSeries, randomHighchartsSeriesWithNamesAndMaxPoints, plotData, randomHighchartsSeriesWithSeed} from './Utils'
@@ -152,6 +153,16 @@ describe(`GeneExpressionTSnePlot`, () => {
       .toJSON()
 
     expect(tree).toMatchSnapshot()
+  })
+
+  test(`contains no atlas autocomplete control when flag is false`, () => {
+    const randomSeries = randomHighchartsSeriesWithSeed()
+    const onSelectGeneId = () => {}
+
+    const wrapper = mount(<GeneExpressionTSnePlot height={600} expressionGradientColours={gradientColourRanges()} atlasUrl={``} suggesterEndpoint={``} onSelectGeneId={onSelectGeneId} loading={true} plotData={plotData(randomSeries)} highlightClusters={[]} speciesName={``} showControls={false}/>)
+
+
+    expect(wrapper.find(AtlasAutocomplete).length).toBe(0)
   })
 
 })

--- a/__test__/GeneExpressionTSnePlot.test.js
+++ b/__test__/GeneExpressionTSnePlot.test.js
@@ -144,9 +144,11 @@ describe(`GeneExpressionTSnePlot colourize function`, () => {
 })
 
 describe(`GeneExpressionTSnePlot`, () => {
+
+  const onSelectGeneId = () => {}
+
   test(`with random data matches snapshot`, () => {
     const randomSeries = randomHighchartsSeriesWithSeed()
-    const onSelectGeneId = () => {}
 
     const tree = renderer
       .create(<GeneExpressionTSnePlot height={600} expressionGradientColours={gradientColourRanges()} atlasUrl={``} suggesterEndpoint={``} onSelectGeneId={onSelectGeneId} loading={true} plotData={plotData(randomSeries)} highlightClusters={[]} speciesName={``}/>)
@@ -157,12 +159,18 @@ describe(`GeneExpressionTSnePlot`, () => {
 
   test(`contains no atlas autocomplete control when flag is false`, () => {
     const randomSeries = randomHighchartsSeriesWithSeed()
-    const onSelectGeneId = () => {}
 
     const wrapper = mount(<GeneExpressionTSnePlot height={600} expressionGradientColours={gradientColourRanges()} atlasUrl={``} suggesterEndpoint={``} onSelectGeneId={onSelectGeneId} loading={true} plotData={plotData(randomSeries)} highlightClusters={[]} speciesName={``} showControls={false}/>)
 
-
     expect(wrapper.find(AtlasAutocomplete).length).toBe(0)
+  })
+
+  test(`contains atlas autocomplete control when flag is not specified`, () => {
+    const randomSeries = randomHighchartsSeriesWithSeed()
+
+    const wrapper = mount(<GeneExpressionTSnePlot height={600} expressionGradientColours={gradientColourRanges()} atlasUrl={``} suggesterEndpoint={``} onSelectGeneId={onSelectGeneId} loading={true} plotData={plotData(randomSeries)} highlightClusters={[]} speciesName={``}/>)
+
+    expect(wrapper.find(AtlasAutocomplete).length).toBe(1)
   })
 
 })

--- a/__test__/__snapshots__/GeneExpressionTSnePlot.test.js.snap
+++ b/__test__/__snapshots__/GeneExpressionTSnePlot.test.js.snap
@@ -1,33 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`GeneExpressionTSnePlot with random data matches snapshot 1`] = `
-<div
-  className="row margin-bottom-large"
->
-  <label>
-    Gene ID, gene name or gene feature
-  </label>
+Array [
   <div
-    style={
-      Object {
-        "display": "",
-      }
-    }
+    className="row margin-bottom-large"
   >
-    <input
-      aria-autocomplete="list"
-      aria-expanded={false}
-      autoComplete="off"
-      name="geneId"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      role="combobox"
-      type="text"
-      value=""
-    />
-  </div>
-</div>
+    <label>
+      Gene ID, gene name or gene feature
+    </label>
+    <div
+      style={
+        Object {
+          "display": "",
+        }
+      }
+    >
+      <input
+        aria-autocomplete="list"
+        aria-expanded={false}
+        autoComplete="off"
+        name="geneId"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        role="combobox"
+        type="text"
+        value=""
+      />
+    </div>
+  </div>,
+  <div
+    style={Object {}}
+  />,
+]
 `;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "expression-atlas-experiment-page-tsne-plot",
-  "version": "3.4.0",
+  "version": "3.5.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expression-atlas-experiment-page-tsne-plot",
-  "version": "3.4.0",
+  "version": "3.5.0-beta",
   "description": "t-SNE plot view tab for Single Cell Expression Atlas experiment page",
   "main": "lib/index.js",
   "scripts": {

--- a/src/ClusterTSnePlot.js
+++ b/src/ClusterTSnePlot.js
@@ -32,7 +32,7 @@ const tooltipHeader = (clusterType, series, point) => {
 const ClusterTSnePlot = (props) => {
   const {ks, perplexities, metadata, selectedPerplexity, onChangePerplexity, selectedColourBy, onChangeColourBy, clusterType} = props  // Select
   const {plotData, highlightClusters, height, tooltipContent} = props   // Chart
-  const {loading, resourcesUrl, errorMessage} = props   // Overlay
+  const {loading, resourcesUrl, errorMessage, showControls} = props   // Overlay
   const opacity = 0.7
 
   const highchartsConfig = {
@@ -150,39 +150,46 @@ const ClusterTSnePlot = (props) => {
     { value: selectedColourBy }
   )
 
-  return [
-    <div key={`perplexity-k-select`} className={`row`}>
-      <div className={`small-12 medium-6 columns`}>
-        <PlotSettingsDropdown
-          labelText={`t-SNE Perplexity`}
-          options={perplexityOptions}
-          defaultValue={{ value: selectedPerplexity, label: selectedPerplexity }}
-          onSelect={(selectedOption) => {onChangePerplexity(selectedOption.value)}}/>
-      </div>
-      <div className={`small-12 medium-6 columns`}>
-        <PlotSettingsDropdown
-          labelText={`Colour plot by:`}
-          options={metadata ? options : kOptions} // Some experiments don't have metadata in Solr, although they should do. Leaving this check in for now so we don't break the entire experiment page.
-          defaultValue={defaultValue}
-          onSelect={(selectedOption) => { onChangeColourBy(selectedOption.group, selectedOption.value)}}/>
-      </div>
-    </div>,
-
-    <ScatterPlotLoader
-      key={`cluster-plot`}
-      wrapperClassName={`row`}
-      chartClassName={`small-12 columns`}
-      series={_colourizeClusters(highlightClusters)(plotData.series)}
-      highchartsConfig={highchartsConfig}
-      loading={loading}
-      resourcesUrl={resourcesUrl}
-      errorMessage={errorMessage}
-    />
-  ]
+  return (
+    [
+      showControls &&
+      <div key={`perplexity-k-select`} className={`row`}>
+        <div className={`small-12 medium-6 columns`}>
+          <PlotSettingsDropdown
+            labelText={`t-SNE Perplexity`}
+            options={perplexityOptions}
+            defaultValue={{value: selectedPerplexity, label: selectedPerplexity}}
+            onSelect={(selectedOption) => {
+              onChangePerplexity(selectedOption.value)
+            }}/>
+        </div>
+        <div className={`small-12 medium-6 columns`}>
+          <PlotSettingsDropdown
+            labelText={`Colour plot by:`}
+            options={metadata ? options : kOptions} // Some experiments don't have metadata in Solr, although they should do. Leaving this check in for now so we don't break the entire experiment page.
+            defaultValue={defaultValue}
+            onSelect={(selectedOption) => {
+              onChangeColourBy(selectedOption.group, selectedOption.value)
+            }}/>
+        </div>
+      </div>,
+      <ScatterPlotLoader
+        key={`cluster-plot`}
+        wrapperClassName={`row`}
+        chartClassName={`small-12 columns`}
+        series={_colourizeClusters(highlightClusters)(plotData.series)}
+        highchartsConfig={highchartsConfig}
+        loading={loading}
+        resourcesUrl={resourcesUrl}
+        errorMessage={errorMessage}
+      />
+    ]
+  )
 }
 
 ClusterTSnePlot.propTypes = {
   height: PropTypes.number.isRequired,
+  showControls: PropTypes.bool,
 
   plotData: PropTypes.shape({
     series: PropTypes.array.isRequired
@@ -207,6 +214,10 @@ ClusterTSnePlot.propTypes = {
   errorMessage: PropTypes.string,
 
   tooltipContent: PropTypes.func
+}
+
+ClusterTSnePlot.defaultProps = {
+  showControls: true
 }
 
 export {ClusterTSnePlot as default, _colourizeClusters, tooltipHeader}

--- a/src/ClusterTSnePlot.js
+++ b/src/ClusterTSnePlot.js
@@ -24,7 +24,7 @@ const _colourizeClusters = (highlightSeries) =>
   })
 
 const tooltipHeader = (clusterType, series, point) => {
-  const clusterName = clusterType === `clusters` ? 
+  const clusterName = clusterType === `clusters` ?
     `<b>Cluster name:</b> ${series.name}<br>` : ``
   return `<b>Cell ID:</b> ${point.name}<br>` + clusterName
 }
@@ -81,11 +81,11 @@ const ClusterTSnePlot = (props) => {
     },
     tooltip: {
       style: {
-        width:`200px`,
-        overflow:`auto`,
+        width: `200px`,
+        overflow: `auto`,
         whiteSpace: `normal`
       },
-      formatter: function(tooltip) {
+      formatter: function (tooltip) {
         // Trick Highcharts into thinking the point is in the bottom half of the chart, so that the tooltip
         // is displayed below the point
         this.point.negative = true
@@ -121,7 +121,7 @@ const ClusterTSnePlot = (props) => {
     label: perplexity
   }))
 
-  const kOptions = ks.sort((a, b) => a-b).map((k) => ({
+  const kOptions = ks.sort((a, b) => a - b).map((k) => ({
     value: k.toString(),
     label: `k = ${k}`,
     group: `clusters`
@@ -147,50 +147,48 @@ const ClusterTSnePlot = (props) => {
     _flatten(
       options.map((item) => (item.options))
     ),
-    { value: selectedColourBy }
+    {value: selectedColourBy}
   )
 
-  return (
-    [
-      <div key={`perplexity-k-select`} className={`row`}>
-        {showControls &&
-        <div className={`small-12 medium-6 columns`}>
-          <PlotSettingsDropdown
-            labelText={`t-SNE Perplexity`}
-            options={perplexityOptions}
-            defaultValue={{value: selectedPerplexity, label: selectedPerplexity}}
-            onSelect={(selectedOption) => {
-              onChangePerplexity(selectedOption.value)
-            }}/>
-        </div>
-        }
-        <div className={`small-12 medium-6 columns`}>
-          <PlotSettingsDropdown
-            labelText={`Colour plot by:`}
-            options={metadata ? options : kOptions} // Some experiments don't have metadata in Solr, although they should do. Leaving this check in for now so we don't break the entire experiment page.
-            defaultValue={defaultValue}
-            onSelect={(selectedOption) => {
-              onChangeColourBy(selectedOption.group, selectedOption.value)
-            }}/>
-        </div>
-      </div>,
-      <ScatterPlotLoader
-        key={`cluster-plot`}
-        wrapperClassName={`row`}
-        chartClassName={`small-12 columns`}
-        series={_colourizeClusters(highlightClusters)(plotData.series)}
-        highchartsConfig={highchartsConfig}
-        loading={loading}
-        resourcesUrl={resourcesUrl}
-        errorMessage={errorMessage}
-      />
-    ]
-  )
+  return [
+    <div key={`perplexity-k-select`} className={`row`}>
+      {showControls &&
+      <div className={`small-12 medium-6 columns`}>
+        <PlotSettingsDropdown
+          labelText={`t-SNE Perplexity`}
+          options={perplexityOptions}
+          defaultValue={{value: selectedPerplexity, label: selectedPerplexity}}
+          onSelect={(selectedOption) => {
+            onChangePerplexity(selectedOption.value)
+          }}/>
+      </div>
+      }
+      <div className={`small-12 medium-6 columns`}>
+        <PlotSettingsDropdown
+          labelText={`Colour plot by:`}
+          options={metadata ? options : kOptions} // Some experiments don't have metadata in Solr, although they should do. Leaving this check in for now so we don't break the entire experiment page.
+          defaultValue={defaultValue}
+          onSelect={(selectedOption) => {
+            onChangeColourBy(selectedOption.group, selectedOption.value)
+          }}/>
+      </div>
+    </div>,
+    <ScatterPlotLoader
+      key={`cluster-plot`}
+      wrapperClassName={`row`}
+      chartClassName={`small-12 columns`}
+      series={_colourizeClusters(highlightClusters)(plotData.series)}
+      highchartsConfig={highchartsConfig}
+      loading={loading}
+      resourcesUrl={resourcesUrl}
+      errorMessage={errorMessage}
+    />
+  ]
 }
 
 ClusterTSnePlot.propTypes = {
   height: PropTypes.number.isRequired,
-  showControls: PropTypes.bool,
+  showControls: PropTypes.bool.isRequired,
 
   plotData: PropTypes.shape({
     series: PropTypes.array.isRequired

--- a/src/ClusterTSnePlot.js
+++ b/src/ClusterTSnePlot.js
@@ -152,8 +152,8 @@ const ClusterTSnePlot = (props) => {
 
   return (
     [
-      showControls &&
       <div key={`perplexity-k-select`} className={`row`}>
+        {showControls &&
         <div className={`small-12 medium-6 columns`}>
           <PlotSettingsDropdown
             labelText={`t-SNE Perplexity`}
@@ -163,6 +163,7 @@ const ClusterTSnePlot = (props) => {
               onChangePerplexity(selectedOption.value)
             }}/>
         </div>
+        }
         <div className={`small-12 medium-6 columns`}>
           <PlotSettingsDropdown
             labelText={`Colour plot by:`}
@@ -214,10 +215,6 @@ ClusterTSnePlot.propTypes = {
   errorMessage: PropTypes.string,
 
   tooltipContent: PropTypes.func
-}
-
-ClusterTSnePlot.defaultProps = {
-  showControls: true
 }
 
 export {ClusterTSnePlot as default, _colourizeClusters, tooltipHeader}

--- a/src/GeneExpressionTSnePlot.js
+++ b/src/GeneExpressionTSnePlot.js
@@ -92,10 +92,9 @@ const _colourizeExpressionLevel = (gradientColours, highlightSeries) => {
 const GeneExpressionScatterPlot = (props) => {
   const {atlasUrl, suggesterEndpoint, geneId, onSelectGeneId, speciesName} = props       // Suggester
   const {height, plotData, expressionGradientColours, highlightClusters} = props  // Chart
-  const {loading, resourcesUrl, errorMessage} = props                       // Overlay
+  const {loading, resourcesUrl, errorMessage, showControls} = props                       // Overlay
   const colourSchema = [`#d4e4fb`,`#95adde`,`#6077bf`,`#1151D1`,`#35419b`,`#0e0573`] // light blue to dark blue
   const colourSchemaLength = colourSchema.length
-
   const plotIsDisabled = !plotData.max
 
   const dataScale = plotIsDisabled ?
@@ -174,33 +173,37 @@ const GeneExpressionScatterPlot = (props) => {
     />
 
   return [
-    <AtlasAutocomplete
-      key={`expression-autocomplete`}
-      wrapperClassName={`row margin-bottom-large`}
-      atlasUrl={atlasUrl}
-      suggesterEndpoint={suggesterEndpoint}
-      initialValue={geneId}
-      defaultSpecies={speciesName}
-      onSelect={ (event) => { onSelectGeneId(event) } }
-    />,
+    showControls &&
+      <AtlasAutocomplete
+        key={`expression-autocomplete`}
+        wrapperClassName={`row margin-bottom-large`}
+        atlasUrl={atlasUrl}
+        suggesterEndpoint={suggesterEndpoint}
+        initialValue={geneId}
+        defaultSpecies={speciesName}
+        onSelect={(event) => {
+          onSelectGeneId(event)
+        }}
+      />,
     //react-responsive design
     <Desktop key={`Desktop`}>
-      {responsiveComponent(1800/2.2)}
-    </Desktop>,
-    <Tablet key={`Tablet`}>
-      {responsiveComponent(1000/2.2)}
-    </Tablet>,
-    <Mobile key={`Mobile`}>
-      {responsiveComponent(750)}
-    </Mobile>,
-    <Default key={`Default`}>
-      {responsiveComponent(350)}
-    </Default>
-  ]
+      {responsiveComponent(1800 / 2.2)}
+      </Desktop>,
+      <Tablet key={`Tablet`}>
+      {responsiveComponent(1000 / 2.2)}
+      </Tablet>,
+      <Mobile key={`Mobile`}>
+        {responsiveComponent(750)}
+      </Mobile>,
+      <Default key={`Default`}>
+        {responsiveComponent(350)}
+      </Default>
+    ]
 }
 
 GeneExpressionScatterPlot.propTypes = {
   height: PropTypes.number.isRequired,
+  showControls: PropTypes.bool,
 
   plotData: PropTypes.shape({
     series: PropTypes.array.isRequired,
@@ -226,6 +229,7 @@ GeneExpressionScatterPlot.propTypes = {
 }
 
 GeneExpressionScatterPlot.defaultProps = {
+  showControls: true,
   expressionGradientColours: [
     {
       colour: `rgb(215, 255, 255)`,

--- a/src/GeneExpressionTSnePlot.js
+++ b/src/GeneExpressionTSnePlot.js
@@ -205,7 +205,7 @@ const GeneExpressionScatterPlot = (props) => {
 
 GeneExpressionScatterPlot.propTypes = {
   height: PropTypes.number.isRequired,
-  showControls: PropTypes.bool,
+  showControls: PropTypes.bool.isRequired,
 
   plotData: PropTypes.shape({
     series: PropTypes.array.isRequired,

--- a/src/GeneExpressionTSnePlot.js
+++ b/src/GeneExpressionTSnePlot.js
@@ -186,19 +186,21 @@ const GeneExpressionScatterPlot = (props) => {
         }}
       />,
     //react-responsive design
-    <Desktop key={`Desktop`}>
-      {responsiveComponent(1800 / 2.2)}
-      </Desktop>,
+    <div key={`scatter-plot`} style={ showControls ? {} : {marginTop: `13%`}}>
+      <Desktop key={`Desktop`}>
+        {responsiveComponent(1800 / 2.2)}
+      </Desktop>
       <Tablet key={`Tablet`}>
-      {responsiveComponent(1000 / 2.2)}
-      </Tablet>,
+        {responsiveComponent(1000 / 2.2)}
+      </Tablet>
       <Mobile key={`Mobile`}>
         {responsiveComponent(750)}
-      </Mobile>,
+      </Mobile>
       <Default key={`Default`}>
         {responsiveComponent(350)}
       </Default>
-    ]
+    </div>
+  ]
 }
 
 GeneExpressionScatterPlot.propTypes = {
@@ -229,7 +231,6 @@ GeneExpressionScatterPlot.propTypes = {
 }
 
 GeneExpressionScatterPlot.defaultProps = {
-  showControls: true,
   expressionGradientColours: [
     {
       colour: `rgb(215, 255, 255)`,

--- a/src/PlotSettingsDropdown.js
+++ b/src/PlotSettingsDropdown.js
@@ -58,7 +58,7 @@ const PlotSettingsDropdown = (props) => {
       components={{ DropdownIndicator, IndicatorSeparator: null }}
       options={options}
       onChange={onSelect}
-      defaultValue={defaultValue}
+      value={defaultValue}
       formatGroupLabel={formatGroupLabel}
       styles={ebiVfSelectStyles} />
   ]

--- a/src/TSnePlotView.js
+++ b/src/TSnePlotView.js
@@ -93,7 +93,7 @@ class TSnePlotView extends React.Component {
   }
 
   render() {
-    const {height, atlasUrl, resourcesUrl, suggesterEndpoint} = this.props
+    const {height, atlasUrl, resourcesUrl, suggesterEndpoint, showControls} = this.props
     const {wrapperClassName, clusterPlotClassName, expressionPlotClassName} = this.props
     const {geneId, speciesName, highlightClusters} = this.props
     const {ks, perplexities, selectedPerplexity, metadata, selectedColourBy, selectedColourByCategory} = this.props
@@ -135,6 +135,7 @@ class TSnePlotView extends React.Component {
             errorMessage={cellClustersErrorMessage}
             tooltipContent={getTooltipContent}
             clusterType={selectedColourByCategory}
+            showControls={showControls}
           />
         </div>
 
@@ -151,6 +152,7 @@ class TSnePlotView extends React.Component {
             loading={loadingGeneExpression}
             resourcesUrl={resourcesUrl}
             errorMessage={geneExpressionErrorMessage}
+            showControls={showControls}
           />
         </div>
       </div>
@@ -174,6 +176,7 @@ TSnePlotView.propTypes = {
   ks: PropTypes.arrayOf(PropTypes.number).isRequired,
   perplexities: PropTypes.arrayOf(PropTypes.number).isRequired,
   selectedPerplexity: PropTypes.number.isRequired,
+  showControls: PropTypes.bool,
 
   metadata: PropTypes.arrayOf(PropTypes.shape({
     value: PropTypes.string,
@@ -193,6 +196,7 @@ TSnePlotView.propTypes = {
 }
 
 TSnePlotView.defaultProps = {
+  showControls: true,
   highlightClusters: [],
   wrapperClassName: `row`,
   clusterPlotClassName: `small-12 medium-6 columns`,

--- a/src/TSnePlotView.js
+++ b/src/TSnePlotView.js
@@ -84,6 +84,8 @@ class TSnePlotView extends React.Component {
       this._fetchAndSetStateCellClusters(this.props)
     } else if (previousProps.geneId !== this.props.geneId) {
       this._fetchAndSetStateGeneId(this.props)
+    } else if (previousProps.selectedColourBy !== this.props.selectedColourBy) {
+      this._fetchAndSetStateCellClusters(this.props)
     }
   }
 

--- a/src/TSnePlotView.js
+++ b/src/TSnePlotView.js
@@ -45,7 +45,7 @@ class TSnePlotView extends React.Component {
         [errorMessageField]: null,
         [loadingField]: false,
       })
-    } catch(e) {
+    } catch (e) {
       this.setState({
         [errorMessageField]: `${e.name}: ${e.message}`,
         [loadingField]: false
@@ -58,10 +58,10 @@ class TSnePlotView extends React.Component {
     const resource =
       selectedColourByCategory === `clusters` ?
         `json/experiments/${experimentAccession}/tsneplot/${selectedPerplexity}/clusters/k/${selectedColourBy}` :
-      selectedColourByCategory === `metadata` ?
-        `json/experiments/${experimentAccession}/tsneplot/${selectedPerplexity}/metadata/${selectedColourBy}` :
-      // We shouldn’t arrive here...
-      undefined
+        selectedColourByCategory === `metadata` ?
+          `json/experiments/${experimentAccession}/tsneplot/${selectedPerplexity}/metadata/${selectedColourBy}` :
+          // We shouldn’t arrive here...
+          undefined
 
     this._fetchAndSetState(
       resource, atlasUrl, `cellClustersData`, `cellClustersErrorMessage`, `loadingCellClusters`)
@@ -76,16 +76,14 @@ class TSnePlotView extends React.Component {
 
   componentDidUpdate(previousProps) {
     if (previousProps.selectedPerplexity !== this.props.selectedPerplexity ||
-        previousProps.experimentAccession !== this.props.experimentAccession) {
+      previousProps.experimentAccession !== this.props.experimentAccession) {
       this._fetchAndSetStateCellClusters(this.props)
       this._fetchAndSetStateGeneId(this.props)
-    } else if (previousProps.selectedColourByCategory !== this.props.selectedColourBy &&
-               previousProps.selectedColourBy !== this.props.selectedColourBy) {
+    } else if (previousProps.selectedColourByCategory !== this.props.selectedColourByCategory ||
+      previousProps.selectedColourBy !== this.props.selectedColourBy) {
       this._fetchAndSetStateCellClusters(this.props)
     } else if (previousProps.geneId !== this.props.geneId) {
       this._fetchAndSetStateGeneId(this.props)
-    } else if (previousProps.selectedColourBy !== this.props.selectedColourBy) {
-      this._fetchAndSetStateCellClusters(this.props)
     }
   }
 
@@ -113,7 +111,7 @@ class TSnePlotView extends React.Component {
         }
 
         return await response.json()
-      } catch(e) {
+      } catch (e) {
         throw new Error(`${e.name}: ${e.message}`)
       }
     }


### PR DESCRIPTION
- Tsne Plot widget uses TsnePlotView component to render tsne plots. In Tsne plot widget we don't need to show the settings controls above the scatter plots. In order to achieve it, a new boolean prop showControls is added to TsnePlotView component to show/hide the controls depending on the flag value.

- Test cases have been added to ClusterTSnePlot and GeneExpressionTSnePlot to check if the controls hide when flag is set to false.

- Default value for prop showControls is set to true. So in principle, this change won't affect the anything where this component is already being used.