### PR TITLE
Bugfix #167076212 – Scale legend symbols

### DIFF
--- a/__test__/GeneExpressionTSnePlot.test.js
+++ b/__test__/GeneExpressionTSnePlot.test.js
@@ -1,8 +1,11 @@
+// fetch polyfill
+import 'whatwg-fetch'
+
 import React from 'react'
 import renderer from 'react-test-renderer'
 import Color from 'color'
 
-import {mount} from 'enzyme'
+import { mount } from 'enzyme'
 
 import '@babel/polyfill'
 import {_colourizeExpressionLevel} from '../src/GeneExpressionTSnePlot'

--- a/__test__/plotloader/ScatterPlot.test.js
+++ b/__test__/plotloader/ScatterPlot.test.js
@@ -1,10 +1,10 @@
 import React from 'react'
 // Highcharts can only be shallow-rendered unless it’s mocked, see __mocks__/highcharts.js
-import {shallow, mount} from 'enzyme'
+import { shallow, mount } from 'enzyme'
 
 import '@babel/polyfill'
 import ScatterPlot from '../../src/plotloader/ScatterPlot'
-import {randomHighchartsSeriesWithSeed} from '../Utils'
+import { randomHighchartsSeriesWithSeed } from '../Utils'
 
 // *IMPORTANT*: Highcharts and React Highcharts aren’t the easiest components to inspect for testing. The mysterious
 //              `n` node was in earlier versions `HighchartsChart`. However the mock was also thinner, so who knows!
@@ -76,6 +76,18 @@ describe(`ScatterPlot`, () => {
 
     expect(markerRadiusLongSeries).not.toBe(markerRadiusShortSeries)
   })
+
+  /* TODO
+   * This test fails because we mock Highcharts and Jest fails if we don’t mock it. Review after we’ve switch to the
+   * official Highcharts React wrapper.
+  test(`afterRender callback is invoked after rendering the component`, done => {
+    const afterRenderSpy = jest.fn(() => {
+      done()
+    })
+
+    shallow(<ScatterPlot series={[]} afterRender={afterRenderSpy} />)
+  })
+  */
 
   test(`matches snapshot with randomized series`, () => {
     const series = randomHighchartsSeriesWithSeed()

--- a/html/Demo.js
+++ b/html/Demo.js
@@ -7,7 +7,7 @@ const experiment1 = {
   accession: `E-ENAD-15`,
   species: `Mus musculus`,
   perplexities: [1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50],
-  ks: [36, 47, 54, 71, 119],
+  ks: [16, 28, 35, 50, 65, 73],
   metadata: [
     {
       value: `characteristic_inferred_cell_type`,
@@ -21,7 +21,7 @@ const experiment2 = {
   accession: `E-MTAB-6701`,
   species: `Homo sapiens`,
   perplexities: [1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50],
-  ks: [55, 82, 99],
+  ks: [8, 21, 43, 53, 63],
   metadata: [
     {
       value: `characteristic_inferred_cell_type`,
@@ -35,7 +35,7 @@ const experiment3 = {
   accession: `E-MTAB-7376`,
   species: `Mus musculus`,
   perplexities: [1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50],
-  ks: [5, 12, 16, 21, 27, 39, 50, 63, 76],
+  ks: [3, 7, 8, 9, 14, 24, 35, 48, 59],
   metadata: [
     {
       value: `characteristic_inferred_cell_type`,
@@ -49,7 +49,7 @@ const experiment4 = {
   accession: `E-MTAB-7324`,
   species: `Mus musculus`,
   perplexities: [1, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50],
-  ks: [5, 10, 14, 15, 19, 27, 39, 47, 53],
+  ks: [8, 12, 15, 18, 29, 37, 48, 50],
   metadata: [
     {
       value: `characteristic_inferred_cell_type`,
@@ -58,7 +58,7 @@ const experiment4 = {
   ]
 }
 
-const { accession, perplexities, ks, metadata, species } = experiment4
+const { accession, perplexities, ks, metadata, species } = experiment1
 
 class Demo extends React.Component {
   constructor(props) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4388,18 +4388,6 @@
         "bser": "^2.0.0"
       }
     },
-    "fetch-mock": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-7.3.3.tgz",
-      "integrity": "sha512-MHKcwZ4n9TmnfnVfelUBrrfxtC9tztafIR+F8l/Yu9N+y48fU1BAwj3iSxhYFYELVw73rCZh2DPWtWCekY/t+w==",
-      "dev": true,
-      "requires": {
-        "babel-polyfill": "^6.26.0",
-        "glob-to-regexp": "^0.4.0",
-        "path-to-regexp": "^2.2.1",
-        "whatwg-url": "^6.5.0"
-      }
-    },
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -5275,12 +5263,6 @@
           }
         }
       }
-    },
-    "glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true
     },
     "global-modules": {
       "version": "2.0.0",
@@ -8036,12 +8018,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-    },
-    "path-to-regexp": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
-      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
-      "dev": true
     },
     "path-type": {
       "version": "2.0.0",
@@ -10801,6 +10777,12 @@
       "requires": {
         "iconv-lite": "0.4.24"
       }
+    },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "enzyme-adapter-react-16": "^1.14.0",
     "eslint": "^6.0.1",
     "eslint-config-gene-expression": "^0.5.0",
-    "fetch-mock": "^7.3.3",
     "file-loader": "^4.0.0",
     "highcharts-series-generator": "^1.0.1",
     "identity-obj-proxy": "^3.0.0",
@@ -81,6 +80,7 @@
     "react-test-renderer": "^16.8.6",
     "webpack": "^4.35.0",
     "webpack-cli": "^3.3.5",
-    "webpack-dev-server": "^3.7.2"
+    "webpack-dev-server": "^3.7.2",
+    "whatwg-fetch": "^3.0.0"
   }
 }

--- a/src/ClusterTSnePlot.js
+++ b/src/ClusterTSnePlot.js
@@ -150,6 +150,17 @@ const ClusterTSnePlot = (props) => {
     {value: selectedColourBy}
   )
 
+  const afterRender = (chart) => {
+    chart.series.forEach(series => {
+      const legendSymbolSize = 10
+      series.legendSymbol.translate(
+        (series.legendSymbol.width / 2) - legendSymbolSize / 2,
+        (series.legendSymbol.height / 2) - legendSymbolSize / 2)
+      series.legendSymbol.attr(`width`, legendSymbolSize)
+      series.legendSymbol.attr(`height`, legendSymbolSize)
+    })
+  }
+
   return [
     <div key={`perplexity-k-select`} className={`row`}>
       {showControls &&
@@ -182,6 +193,7 @@ const ClusterTSnePlot = (props) => {
       loading={loading}
       resourcesUrl={resourcesUrl}
       errorMessage={errorMessage}
+      afterRender={afterRender}
     />
   ]
 }

--- a/src/plotloader/PlotLoader.js
+++ b/src/plotloader/PlotLoader.js
@@ -7,19 +7,22 @@ import ScatterPlot from './ScatterPlot'
 import SeriesPropTypes from './SeriesPropTypes'
 
 const PlotLoader = ({loading, series, errorMessage, highchartsConfig, resourcesUrl, wrapperClassName, chartClassName,
-  legendWidth}) =>
+  legendWidth, afterRender}) =>
   errorMessage ?
     <div className={`${wrapperClassName} text-center scxa-error`}>
       <p>{errorMessage}</p>
     </div> :
 
     <div style={{position: `relative`}} className={wrapperClassName}>
-      <ScatterPlot chartClassName={chartClassName}
+      <ScatterPlot
+        chartClassName={chartClassName}
         series={series}
         highchartsConfig={highchartsConfig}
-        legendWidth ={legendWidth}
+        legendWidth={legendWidth}
+        afterRender={afterRender}
       />
-      <LoadingOverlay show={loading}
+      <LoadingOverlay
+        show={loading}
         resourcesUrl={resourcesUrl}
       />
     </div>
@@ -32,14 +35,16 @@ PlotLoader.propTypes = {
   chartClassName: PropTypes.string,
   resourcesUrl: PropTypes.string,
   legendWidth: PropTypes.number,
-  wrapperClassName: PropTypes.string
+  wrapperClassName: PropTypes.string,
+  afterRender: PropTypes.func
 }
 
 PlotLoader.defaultProps = {
   wrapperClassName: ``,
   chartClassName: ``,
   highchartsConfig: {},
-  resourcesUrl: ``
+  resourcesUrl: ``,
+  afterRender: () => {}
 }
 
 export default PlotLoader

--- a/src/plotloader/ScatterPlot.js
+++ b/src/plotloader/ScatterPlot.js
@@ -217,7 +217,7 @@ const ScatterPlot = (props) => {
 
   return (
     <div className={chartClassName}>
-      <ReactHighcharts config={config}/>
+      <ReactHighcharts config={config} callback={props.afterRender} />
     </div>
   )
 }

--- a/src/plotloader/ScatterPlot.js
+++ b/src/plotloader/ScatterPlot.js
@@ -226,7 +226,8 @@ ScatterPlot.propTypes = {
   chartClassName: PropTypes.string,
   series: SeriesPropTypes,
   highchartsConfig: PropTypes.object,
-  legendWidth: PropTypes.number
+  legendWidth: PropTypes.number,
+  afterRender: PropTypes.func.isRequired
 }
 
 ScatterPlot.defaultProps = {


### PR DESCRIPTION
Use `react-highcharts` callback prop to resize legend symbols after the chart has been rendered. Unfortunately, Highcharts API doesn’t have any way to do this. `legend.symbolHeight` and `legend.symbolWidth` are only for square-symbols (pies, bar charts, etc.).

It’s a shame that there’s no way to test this (see the `TODO` comment in the test). I hope we’ll be able to do something about this when we move to Highcharts’ official React component.